### PR TITLE
feat(onboarding): explain relay setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ After a task needs non-obvious investigation, repeated failed attempts, or a rec
 - Agent workflow, operational runbooks, and environment traps go here.
 - A reproducible code failure gets an automated test instead of a paragraph.
 - Record only evidence-backed, reusable guidance. No credentials, no transient PIDs, no diary of one-off failures.
-- GitHub prerequisite failures are server-classified and resolved in the app; never send users to Terminal. Keep copy minimal, open browser-based setup automatically, and retain the device code as recovery.
+- GitHub prerequisite and onboarding flows are server-classified and resolved in-app; never send users to Terminal. Match the landing page: one short headline, no subtitle, flat controls, and only copy needed for the next action; open browser setup automatically and retain the device code as recovery.
 - The Forgejo host mounts `/run` with `noexec`; invoke migration helpers through `bash` or `python3` rather than executing files there directly.
 - Forgejo hides pull requests when `repository.is_mirror` is true even if the unit is enabled. Keep the `mirror` row, clear only `is_mirror`, limit its refspecs to heads and tags, and maintain each native PR's hidden `refs/pull/<N>/head`; create an ordinary fallback branch only for an active fork PR and write both refs as UID/GID `994:984`.
 - Long authenticated browser benchmarks run one measured process at a time. Retry and discard only transport-failed iterations, checkpoint each complete product sample set under `.scratch`, and publish only after every product reaches the declared successful sample count.

--- a/scripts/shoot-views.mjs
+++ b/scripts/shoot-views.mjs
@@ -755,7 +755,7 @@ const scenarios = [
   },
   onboardingStep("onboarding-step-1-connect", 1, "Successful GitHub authentication step."),
   onboardingStep("onboarding-step-2-repositories", 2, "Successful repository selection step."),
-  onboardingStep("onboarding-step-3-live-updates", 3, "Hosted GitHub App installation guidance."),
+  onboardingStep("onboarding-step-3-live-updates", 3, "Minimal hosted relay setup."),
   onboardingStep("onboarding-step-4-ready", 4, "Successful initial inbox sync step."),
   {
     name: "quota-exhausted",
@@ -830,10 +830,10 @@ function onboardingStep(name, step, description) {
       await page.getByText(`Step ${step} of 4`, { exact: true }).waitFor();
       if (step === 1) await page.getByText("Connected as", { exact: false }).waitFor();
       if (step === 3) {
-        await page.getByRole("button", { name: "Install GitHub App", exact: true }).waitFor();
-        await page.getByRole("button", { name: "Use polling instead", exact: true }).waitFor();
+        await page.getByRole("button", { name: "Install on GitHub", exact: true }).waitFor();
+        await page.getByRole("button", { name: "Use polling", exact: true }).waitFor();
         await page.getByRole("link", { name: "Source", exact: true }).waitFor();
-        await page.getByRole("link", { name: "Self-hosting guide", exact: true }).waitFor();
+        await page.getByRole("link", { name: "Self-host", exact: true }).waitFor();
       }
       if (step === 4) await page.getByText("Your inbox is ready.", { exact: true }).waitFor();
     },
@@ -877,7 +877,7 @@ async function advanceOnboarding(page, targetStep) {
   await page.locator(".repo-row input").first().check();
   await page.getByRole("button", { name: "Continue with 1", exact: true }).click();
   if (targetStep === 3) return;
-  await page.getByRole("button", { name: "Use polling instead", exact: true }).click();
+  await page.getByRole("button", { name: "Use polling", exact: true }).click();
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await page.getByText("Your inbox is ready.", { exact: true }).waitFor();
 }

--- a/scripts/shoot-views.mjs
+++ b/scripts/shoot-views.mjs
@@ -755,7 +755,7 @@ const scenarios = [
   },
   onboardingStep("onboarding-step-1-connect", 1, "Successful GitHub authentication step."),
   onboardingStep("onboarding-step-2-repositories", 2, "Successful repository selection step."),
-  onboardingStep("onboarding-step-3-live-updates", 3, "Successful live-update coverage step."),
+  onboardingStep("onboarding-step-3-live-updates", 3, "Hosted GitHub App installation guidance."),
   onboardingStep("onboarding-step-4-ready", 4, "Successful initial inbox sync step."),
   {
     name: "quota-exhausted",
@@ -823,19 +823,24 @@ function onboardingStep(name, step, description) {
     route: "#/",
     description,
     prepare: clearConfiguredRepos,
-    beforeGoto: onboardingFixtureRoutes,
+    beforeGoto: (page) => onboardingFixtureRoutes(page, { relayCovered: step < 3 }),
     ready: ".onb-page",
     interact: step === 1 ? undefined : async (page) => advanceOnboarding(page, step),
     verify: async (page) => {
       await page.getByText(`Step ${step} of 4`, { exact: true }).waitFor();
       if (step === 1) await page.getByText("Connected as", { exact: false }).waitFor();
-      if (step === 3) await page.getByText("Live updates confirmed for every selected repository.", { exact: true }).waitFor();
+      if (step === 3) {
+        await page.getByRole("button", { name: "Install GitHub App", exact: true }).waitFor();
+        await page.getByRole("button", { name: "Use polling instead", exact: true }).waitFor();
+        await page.getByRole("link", { name: "Source", exact: true }).waitFor();
+        await page.getByRole("link", { name: "Self-hosting guide", exact: true }).waitFor();
+      }
       if (step === 4) await page.getByText("Your inbox is ready.", { exact: true }).waitFor();
     },
   };
 }
 
-async function onboardingFixtureRoutes(page) {
+async function onboardingFixtureRoutes(page, { relayCovered = true } = {}) {
   await page.route("**/api/auth/status", (route) => route.fulfill({
     status: 200,
     contentType: "application/json",
@@ -854,7 +859,7 @@ async function onboardingFixtureRoutes(page) {
     return route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ repos: Object.fromEntries(repos.map((repo) => [repo, true])), installUrl: "https://github.com/apps/pr-cockpit" }),
+      body: JSON.stringify({ repos: Object.fromEntries(repos.map((repo) => [repo, relayCovered])), installUrl: "https://github.com/apps/pr-cockpit" }),
     });
   });
   await page.route("**/api/refresh", (route) => route.fulfill({
@@ -871,8 +876,8 @@ async function advanceOnboarding(page, targetStep) {
   if (targetStep === 2) return;
   await page.locator(".repo-row input").first().check();
   await page.getByRole("button", { name: "Continue with 1", exact: true }).click();
-  await page.getByText("Live updates confirmed for every selected repository.", { exact: true }).waitFor();
   if (targetStep === 3) return;
+  await page.getByRole("button", { name: "Use polling instead", exact: true }).click();
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await page.getByText("Your inbox is ready.", { exact: true }).waitFor();
 }

--- a/ui/src/lib/Onboarding.svelte
+++ b/ui/src/lib/Onboarding.svelte
@@ -236,8 +236,7 @@
 
     {#if step === 1}
       <span class="eyebrow">Step 1 of 4</span>
-      <h1 class="onb-title">Connect GitHub</h1>
-      <p class="onb-sub">PR Cockpit uses the GitHub CLI already installed on your computer.</p>
+      <h1 class="onb-title">Connect GitHub.</h1>
 
       <div class="status-card" aria-live="polite">
         {#if authLoading}
@@ -260,8 +259,7 @@
       </div>
     {:else if step === 2}
       <span class="eyebrow">Step 2 of 4</span>
-      <h1 class="onb-title">Choose repositories</h1>
-      <p class="onb-sub">Pick the repositories whose pull requests should land in your inbox.</p>
+      <h1 class="onb-title">Choose repositories.</h1>
 
       {#if repoError}
         <div class="notice failure-notice" role="alert">
@@ -328,68 +326,55 @@
       </div>
     {:else if step === 3}
       <span class="eyebrow">Step 3 of 4</span>
-      <h1 class="onb-title">Keep your inbox current</h1>
-      <p class="onb-sub">Install the free GitHub App for live updates, or continue with periodic polling.</p>
+      <h1 class="onb-title">Always up to date.</h1>
 
-      <div class="relay-card">
-        <div class="relay-heading">
-          <strong>Hosted relay</strong>
-          <span>Free</span>
-        </div>
+      {#if !coverageConfirmed && !skippedLive}
+        <p class="relay-copy">Install the free GitHub App, choose repositories, then return.</p>
+      {/if}
 
-        {#if !coverageConfirmed && !skippedLive}
-          <ol class="relay-steps">
-            <li>Open GitHub and choose your account.</li>
-            <li>Grant access to the repositories selected here.</li>
-            <li>Return to PR Cockpit. Live updates are confirmed automatically.</li>
-          </ol>
-        {/if}
-
+      {#if coverageState !== "ready" && coverageState !== "idle"}
         <div class="status-card coverage-card" aria-live="polite">
           {#if coverageState === "checking"}
             <span class="spinner" aria-hidden="true"></span>
-            <span>Checking coverage for {chosen.length} {chosen.length === 1 ? "repository" : "repositories"}…</span>
+            <span>Checking {chosen.length} {chosen.length === 1 ? "repository" : "repositories"}…</span>
           {:else if coverageConfirmed}
             <span class="status-mark success" aria-hidden="true">✓</span>
-            <span>Live updates confirmed for every selected repository.</span>
+            <span>Live updates are on.</span>
           {:else if coverageState === "polling"}
             <span class="spinner" aria-hidden="true"></span>
-            <span>Waiting for the GitHub App installation to cover every selected repository…</span>
+            <span>Waiting for GitHub…</span>
           {:else if skippedLive}
             <span class="status-mark" aria-hidden="true">→</span>
-            <span>Polling selected. PR Cockpit will refresh from GitHub every few minutes.</span>
+            <span>Polling every few minutes.</span>
           {:else if coverageError}
             <span class="status-mark failure" aria-hidden="true">!</span>
             <span>{coverageError}</span>
-          {:else}
-            <span class="status-mark" aria-hidden="true">→</span>
-            <span>The GitHub App still needs access to one or more selected repositories.</span>
           {/if}
         </div>
+      {/if}
 
-        {#if !coverageConfirmed && !skippedLive}
-          <div class="live-actions">
-            {#if coverage?.installUrl}
-              <button class="primary" type="button" onclick={installApp}>Install GitHub App</button>
-            {/if}
-            {#if coverageState === "failed"}
-              <button class="secondary" type="button" onclick={checkCoverage}>Retry check</button>
-            {/if}
-          </div>
-        {/if}
-      </div>
+      {#if !coverageConfirmed && !skippedLive}
+        <div class="live-actions">
+          {#if coverage?.installUrl}
+            <button class="primary" type="button" onclick={installApp}>Install on GitHub</button>
+          {/if}
+          {#if coverageState === "failed"}
+            <button class="secondary" type="button" onclick={checkCoverage}>Retry check</button>
+          {/if}
+        </div>
+      {/if}
 
-      <p class="relay-disclosure">
-        The hosted relay is an open-source Cloudflare Worker. It stores compact event markers and workflow statuses—not PR bodies, comments, diffs, or logs. Your GitHub token verifies repository access and is never stored.
+      <p class="relay-meta">
+        Open-source Cloudflare relay. Stores event markers only—no PR data or logs.
         <a href="https://github.com/theolundqvist/pr-cockpit/tree/main/relay" target="_blank" rel="noreferrer">Source</a>
         <span aria-hidden="true">·</span>
-        <a href="https://github.com/theolundqvist/pr-cockpit/blob/main/docs/self-host-relay.md" target="_blank" rel="noreferrer">Self-hosting guide</a>
+        <a href="https://github.com/theolundqvist/pr-cockpit/blob/main/docs/self-host-relay.md" target="_blank" rel="noreferrer">Self-host</a>
       </p>
 
       <div class="polling-option">
-        <span>Without a relay, PR Cockpit still works by polling GitHub every few minutes, but the inbox is not guaranteed to be current.</span>
+        <span>No relay: polling may be stale.</span>
         {#if !coverageConfirmed && !skippedLive}
-          <button class="link-button" type="button" onclick={skipLiveUpdates}>Use polling instead</button>
+          <button class="link-button" type="button" onclick={skipLiveUpdates}>Use polling</button>
         {/if}
       </div>
 
@@ -399,8 +384,7 @@
       </div>
     {:else}
       <span class="eyebrow">Step 4 of 4</span>
-      <h1 class="onb-title">Build your inbox</h1>
-      <p class="onb-sub">Your settings are saved before PR Cockpit runs the first GitHub sync.</p>
+      <h1 class="onb-title">Build your inbox.</h1>
 
       <div class="sync-list" aria-live="polite">
         <div class:complete={syncState !== "saving" && syncState !== "idle"}>
@@ -482,18 +466,12 @@
     text-transform: none;
   }
   .onb-title {
-    margin: 0 0 8px;
+    margin: 0 0 28px;
     color: var(--text);
-    font-size: 24px;
-    font-weight: 500;
-    line-height: 30px;
-    letter-spacing: -0.025em;
-  }
-  .onb-sub {
-    margin: 0 0 24px;
-    color: var(--text-dim);
-    font-size: 14px;
-    line-height: 20px;
+    font-size: 32px;
+    font-weight: 620;
+    line-height: 34px;
+    letter-spacing: -0.048em;
   }
   .status-card,
   .notice {
@@ -656,39 +634,15 @@
     color: var(--fail);
     font-size: 11.5px;
   }
-  .relay-card {
-    padding: 16px;
-    border-radius: var(--radius-md);
-    background: var(--surface);
-  }
-  .relay-heading {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 12px;
-    color: var(--text);
-    font-size: 13px;
-  }
-  .relay-heading span {
-    padding: 2px 7px;
-    border-radius: 999px;
-    background: var(--ready-bg);
-    color: var(--ready);
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-  }
-  .relay-steps {
-    display: grid;
-    gap: 5px;
-    margin: 0 0 14px;
-    padding-left: 22px;
+  .relay-copy {
+    margin: 0;
     color: var(--text-dim);
-    font-size: 12px;
+    font-size: 13px;
     line-height: 1.45;
   }
   .coverage-card {
     min-height: 44px;
+    margin-top: 16px;
     padding: 0;
     background: transparent;
   }
@@ -699,20 +653,19 @@
     gap: 10px;
     margin-top: 14px;
   }
-  .relay-disclosure {
-    margin: 12px 0 0;
+  .relay-meta {
+    margin-top: 22px;
+    padding-top: 14px;
+    border-top: 1px solid var(--border);
     color: var(--text-faint);
     font-size: 11px;
     line-height: 1.5;
   }
-  .relay-disclosure a {
+  .relay-meta a {
     color: var(--link);
     text-decoration: none;
   }
-  .relay-disclosure a:first-of-type {
-    margin-left: 4px;
-  }
-  .relay-disclosure a:hover {
+  .relay-meta a:hover {
     text-decoration: underline;
   }
   .polling-option {
@@ -720,7 +673,7 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 16px;
-    margin-top: 12px;
+    margin-top: 16px;
     color: var(--text-dim);
     font-size: 11px;
     line-height: 1.45;

--- a/ui/src/lib/Onboarding.svelte
+++ b/ui/src/lib/Onboarding.svelte
@@ -328,42 +328,70 @@
       </div>
     {:else if step === 3}
       <span class="eyebrow">Step 3 of 4</span>
-      <h1 class="onb-title">Enable live updates</h1>
-      <p class="onb-sub">A shared relay delivers GitHub events within seconds, with no relay account needed.</p>
+      <h1 class="onb-title">Keep your inbox current</h1>
+      <p class="onb-sub">Install the free GitHub App for live updates, or continue with periodic polling.</p>
 
-      <div class="status-card coverage-card" aria-live="polite">
-        {#if coverageState === "checking"}
-          <span class="spinner" aria-hidden="true"></span>
-          <span>Checking coverage for {chosen.length} {chosen.length === 1 ? "repository" : "repositories"}…</span>
-        {:else if coverageConfirmed}
-          <span class="status-mark success" aria-hidden="true">✓</span>
-          <span>Live updates confirmed for every selected repository.</span>
-        {:else if coverageState === "polling"}
-          <span class="spinner" aria-hidden="true"></span>
-          <span>Waiting for the GitHub App installation to cover every selected repository…</span>
-        {:else if skippedLive}
-          <span class="status-mark" aria-hidden="true">→</span>
-          <span>Live updates skipped. PR Cockpit will poll GitHub every few minutes.</span>
-        {:else if coverageError}
-          <span class="status-mark failure" aria-hidden="true">!</span>
-          <span>{coverageError}</span>
-        {:else}
-          <span class="status-mark" aria-hidden="true">→</span>
-          <span>Install the GitHub App for repositories that are not covered yet.</span>
+      <div class="relay-card">
+        <div class="relay-heading">
+          <strong>Hosted relay</strong>
+          <span>Free</span>
+        </div>
+
+        {#if !coverageConfirmed && !skippedLive}
+          <ol class="relay-steps">
+            <li>Open GitHub and choose your account.</li>
+            <li>Grant access to the repositories selected here.</li>
+            <li>Return to PR Cockpit. Live updates are confirmed automatically.</li>
+          </ol>
+        {/if}
+
+        <div class="status-card coverage-card" aria-live="polite">
+          {#if coverageState === "checking"}
+            <span class="spinner" aria-hidden="true"></span>
+            <span>Checking coverage for {chosen.length} {chosen.length === 1 ? "repository" : "repositories"}…</span>
+          {:else if coverageConfirmed}
+            <span class="status-mark success" aria-hidden="true">✓</span>
+            <span>Live updates confirmed for every selected repository.</span>
+          {:else if coverageState === "polling"}
+            <span class="spinner" aria-hidden="true"></span>
+            <span>Waiting for the GitHub App installation to cover every selected repository…</span>
+          {:else if skippedLive}
+            <span class="status-mark" aria-hidden="true">→</span>
+            <span>Polling selected. PR Cockpit will refresh from GitHub every few minutes.</span>
+          {:else if coverageError}
+            <span class="status-mark failure" aria-hidden="true">!</span>
+            <span>{coverageError}</span>
+          {:else}
+            <span class="status-mark" aria-hidden="true">→</span>
+            <span>The GitHub App still needs access to one or more selected repositories.</span>
+          {/if}
+        </div>
+
+        {#if !coverageConfirmed && !skippedLive}
+          <div class="live-actions">
+            {#if coverage?.installUrl}
+              <button class="primary" type="button" onclick={installApp}>Install GitHub App</button>
+            {/if}
+            {#if coverageState === "failed"}
+              <button class="secondary" type="button" onclick={checkCoverage}>Retry check</button>
+            {/if}
+          </div>
         {/if}
       </div>
 
-      {#if !coverageConfirmed && !skippedLive}
-        <div class="live-actions">
-          {#if coverage?.installUrl}
-            <button class="primary" type="button" onclick={installApp} disabled={coverageState === "polling"}>Install GitHub App</button>
-          {/if}
-          {#if coverageState === "failed"}
-            <button class="secondary" type="button" onclick={checkCoverage}>Retry check</button>
-          {/if}
-          <button class="link-button" type="button" onclick={skipLiveUpdates}>Skip — poll every few minutes</button>
-        </div>
-      {/if}
+      <p class="relay-disclosure">
+        The hosted relay is an open-source Cloudflare Worker. It stores compact event markers and workflow statuses—not PR bodies, comments, diffs, or logs. Your GitHub token verifies repository access and is never stored.
+        <a href="https://github.com/theolundqvist/pr-cockpit/tree/main/relay" target="_blank" rel="noreferrer">Source</a>
+        <span aria-hidden="true">·</span>
+        <a href="https://github.com/theolundqvist/pr-cockpit/blob/main/docs/self-host-relay.md" target="_blank" rel="noreferrer">Self-hosting guide</a>
+      </p>
+
+      <div class="polling-option">
+        <span>Without a relay, PR Cockpit still works by polling GitHub every few minutes, but the inbox is not guaranteed to be current.</span>
+        {#if !coverageConfirmed && !skippedLive}
+          <button class="link-button" type="button" onclick={skipLiveUpdates}>Use polling instead</button>
+        {/if}
+      </div>
 
       <div class="actions">
         <button class="secondary shortcut-action" type="button" onclick={() => (stopCoveragePolling(), step = 2)}>Back <Kbd keys="esc" /></button>
@@ -628,8 +656,41 @@
     color: var(--fail);
     font-size: 11.5px;
   }
+  .relay-card {
+    padding: 16px;
+    border-radius: var(--radius-md);
+    background: var(--surface);
+  }
+  .relay-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    color: var(--text);
+    font-size: 13px;
+  }
+  .relay-heading span {
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: var(--ready-bg);
+    color: var(--ready);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .relay-steps {
+    display: grid;
+    gap: 5px;
+    margin: 0 0 14px;
+    padding-left: 22px;
+    color: var(--text-dim);
+    font-size: 12px;
+    line-height: 1.45;
+  }
   .coverage-card {
     min-height: 44px;
+    padding: 0;
+    background: transparent;
   }
   .live-actions {
     display: flex;
@@ -637,6 +698,36 @@
     align-items: center;
     gap: 10px;
     margin-top: 14px;
+  }
+  .relay-disclosure {
+    margin: 12px 0 0;
+    color: var(--text-faint);
+    font-size: 11px;
+    line-height: 1.5;
+  }
+  .relay-disclosure a {
+    color: var(--link);
+    text-decoration: none;
+  }
+  .relay-disclosure a:first-of-type {
+    margin-left: 4px;
+  }
+  .relay-disclosure a:hover {
+    text-decoration: underline;
+  }
+  .polling-option {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 12px;
+    color: var(--text-dim);
+    font-size: 11px;
+    line-height: 1.45;
+  }
+  .polling-option .link-button {
+    flex: none;
+    white-space: nowrap;
   }
   .actions {
     display: flex;


### PR DESCRIPTION
Onboarding previously explained the relay with dense cards and subtitle copy that did not match the product landing page.

Setup now uses one short headline per step, flat actions, and only the instruction needed to continue. “Always up to date.” leads directly to GitHub App installation and confirms the connection automatically on return.

The source, self-hosting guide, Cloudflare data boundary, and relay-free freshness caveat remain visible in one compact footer.

## How it works

![GitHub App events flow through a marker-only relay to local PR Cockpit](https://github.com/user-attachments/assets/300277c8-fbae-4f92-af83-4dc9ad49b148)

## Screenshots

### 1. Connect GitHub

| Before | After |
| --- | --- |
| ![Connect GitHub before](https://github.com/user-attachments/assets/c53e63b8-ed75-43e8-a1c4-701b18e83d0c) | ![Connect GitHub after](https://github.com/user-attachments/assets/b0392413-a124-4305-b3a3-1b53f9cd5fed) |

### 2. Choose repositories

| Before | After |
| --- | --- |
| ![Choose repositories before](https://github.com/user-attachments/assets/5cab6824-66ae-45e2-8375-a214cfabb78e) | ![Choose repositories after](https://github.com/user-attachments/assets/55ef52cf-833f-4031-84a6-dbb35c289615) |

### 3. Configure live updates

| Before | After |
| --- | --- |
| ![Live updates before](https://github.com/user-attachments/assets/8bba049e-9033-40b6-a999-8e7d05a426a0) | ![Live updates after](https://github.com/user-attachments/assets/6fbebe0e-2e5c-4941-a44c-77cbc79f3d98) |

### 4. Build the inbox

| Before | After |
| --- | --- |
| ![Build inbox before](https://github.com/user-attachments/assets/e96a9600-d50c-4586-b1c6-22397bb2732d) | ![Build inbox after](https://github.com/user-attachments/assets/55b2512d-7214-48df-9aab-0e959697d11a) |
