### PR TITLE
fix(nav): preserve forward history

### DIFF
--- a/ui/src/lib/HistoryNav.svelte
+++ b/ui/src/lib/HistoryNav.svelte
@@ -1,12 +1,7 @@
 <script>
-  import { history, goBack, goForward } from "./history.svelte.js";
+  import { history, goBackOrFallback, goForward } from "./history.svelte.js";
 
   let { backFallback = null } = $props();
-
-  function navigateBack() {
-    if (backFallback) location.hash = backFallback;
-    else if (history.canBack) goBack();
-  }
 
 </script>
 
@@ -14,7 +9,7 @@
   <button
     class="arrow"
     disabled={!history.canBack && !backFallback}
-    onclick={navigateBack}
+    onclick={() => goBackOrFallback(backFallback)}
     title={backFallback ? "Back to inbox" : "Back"}
     aria-label={backFallback ? "Back to inbox" : "Back"}
   >

--- a/ui/src/lib/history.svelte.js
+++ b/ui/src/lib/history.svelte.js
@@ -1,3 +1,5 @@
+import { historyBackAction } from "./historyAction.js";
+
 export const history = $state({ canBack: false, canForward: false });
 
 export function goBack() {
@@ -6,6 +8,12 @@ export function goBack() {
 
 export function goForward() {
   if (history.canForward) window.history.forward();
+}
+
+export function goBackOrFallback(fallback) {
+  const action = historyBackAction(history.canBack, fallback);
+  if (action === "back") goBack();
+  else if (action === "fallback") location.hash = fallback;
 }
 
 export function initHistory() {

--- a/ui/src/lib/history.test.js
+++ b/ui/src/lib/history.test.js
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { historyBackAction } from "./historyAction.js";
+
+test("Back preserves a forward entry and uses the inbox only as a true fallback", () => {
+  expect(historyBackAction(true, "#/")).toBe("back");
+  expect(historyBackAction(false, "#/")).toBe("fallback");
+  expect(historyBackAction(false, null)).toBe("none");
+});

--- a/ui/src/lib/historyAction.js
+++ b/ui/src/lib/historyAction.js
@@ -1,0 +1,1 @@
+export const historyBackAction = (canBack, fallback) => canBack ? "back" : fallback ? "fallback" : "none";


### PR DESCRIPTION
The PR header always has an inbox fallback, so Back previously assigned `#/` directly even when browser history could navigate normally. That new hash entry destroyed the Forward entry, leaving the Forward arrow disabled after returning to the queue.

## What changed

- Prefer `window.history.back()` whenever a previous entry exists.
- Use the inbox fallback only when the window has no Back entry.
- Keep the fallback decision in one tested helper shared by the header action.

## Verification

- `bun test ui/src/lib/history.test.js` — 1 passed.
- `cd ui && bun run build`.
- Browser replay: inbox → PR → Back preserves an enabled Forward button and Forward returns to the same PR.

## Screenshots

| Before | After |
|---|---|
| ![Forward disabled after returning to the inbox](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/history/before.png) | ![Forward preserved after returning to the inbox](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/history/after.png) |

## Defaults

- [x] New functionality is off by default, if applicable. This restores standard browser-history behavior.
- [x] Styling is opt-in, or this is minor polish that preserves the default appearance. This changes no styling.
