### PR TITLE
fix(diff): expose the full PR range

### DIFF
--- a/ui/src/lib/PrDetail.svelte
+++ b/ui/src/lib/PrDetail.svelte
@@ -2507,6 +2507,9 @@
                 onSelect={selectRange}
                 bind:open={rangeOpen}
               />
+              {#if rangeKey !== "all"}
+                <button class="toolbar-btn" onclick={() => selectRange("all")}>All changes</button>
+              {/if}
             </div>
             {#if testFiles.length && diffState === "ready"}
               <button class="toolbar-btn shortcut-action" onclick={toggleTests}>


### PR DESCRIPTION
Selecting one commit or a commit range changes the Files view, but returning to the full pull-request diff requires reopening the range picker and finding **All changes** again.

## What changed

- Show an **All changes** toolbar action whenever `rangeKey !== "all"`.
- Reuse the existing `selectRange("all")` path; no new diff state or fetching behavior is introduced.
- Hide the action when the complete PR range is already active.

## Verification

- `cd ui && bun run build`.
- Browser check selects the same fixture commit on both builds: the baseline has no reset action; the branch exposes **All changes**.

## Screenshots

**Before — the selected commit has no visible path back to the full PR range**

![Selected commit without a visible full-diff reset](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/08efccf933770866628a9a9b03ec86d7a12fc029/screenshots/diff/focused-before.png)

**After — All changes is visible beside the selected commit**

![Selected commit with a visible All changes reset](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/08efccf933770866628a9a9b03ec86d7a12fc029/screenshots/diff/focused-after.png)

## Defaults

- [x] New functionality is off by default, if applicable. The action appears only while a narrower range is active.
- [x] Styling is opt-in, or this is minor polish that preserves the default appearance. It reuses the existing toolbar control style.
