### PR TITLE
feat(queue): filter every view by repository

### DIFF
--- a/ui/src/lib/ActionsPage.svelte
+++ b/ui/src/lib/ActionsPage.svelte
@@ -4,6 +4,7 @@
   import { prefetchRepoRun, rememberActionRun } from "./actionPrefetch.js";
   import { fetchRepoActions, fetchSettings } from "./api.js";
   import { durationText, relativeTime } from "./time.js";
+  import { isTypingTarget } from "./dom.js";
 
   let {
     repos: routeRepos = [],
@@ -25,6 +26,7 @@
   const validStatuses = new Set(statusOptions.map((option) => option.id));
 
   let selectedRepos = $state([]);
+  let repoPickerOpen = $state(false);
   let selectedWorkflows = $state([]);
   let selectedStatus = $state("all");
   let initialized = $state(false);
@@ -69,12 +71,27 @@
   }
 
   function updateFilters(next) {
-    syncSelection({
+    const selection = {
       repos: next.repos ?? selectedRepos,
       workflows: next.workflows ?? selectedWorkflows,
       status: next.status ?? selectedStatus,
-    });
+    };
+    syncSelection(selection);
+    if (next.repos !== undefined) {
+      if (selection.repos.length) localStorage.setItem("cockpit:repository-scope", JSON.stringify(selection.repos));
+      else localStorage.removeItem("cockpit:repository-scope");
+    }
   }
+
+  $effect(() => {
+    const onKey = (event) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || isTypingTarget(event.target) || event.key.toLowerCase() !== "r") return;
+      repoPickerOpen = !repoPickerOpen;
+      event.preventDefault();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
 
   function runDuration(run) {
     if (run.runStartedAt && run.updatedAt) return durationText(run.runStartedAt, run.updatedAt);
@@ -204,7 +221,7 @@
       {/each}
     </div>
     <div class="filter-pickers">
-      <MultiSelectDropdown label="Repository" options={snapshot?.repos ?? []} selected={selectedRepos} plural="repositories" onchange={(repos) => updateFilters({ repos })} />
+      <MultiSelectDropdown label="Repository" options={snapshot?.repos ?? []} selected={selectedRepos} plural="repositories" keybind="r" bind:open={repoPickerOpen} onchange={(repos) => updateFilters({ repos })} />
       <MultiSelectDropdown label="Workflow" options={workflowOptions} selected={selectedWorkflows} plural="workflows" onchange={(workflows) => updateFilters({ workflows })} />
     </div>
   </section>

--- a/ui/src/lib/Inbox.svelte
+++ b/ui/src/lib/Inbox.svelte
@@ -19,6 +19,7 @@
   import UpdateButton from "./UpdateButton.svelte";
   import { timedFlag } from "./timedFlag.svelte.js";
   import { prKey } from "./prKey.js";
+  import { availableRepositories, filterByRepository } from "./repoFilter.js";
   import { showFlash } from "./flash.svelte.js";
   import CurrentBranchBadge from "./CurrentBranchBadge.svelte";
   import Kbd from "./Kbd.svelte";
@@ -70,6 +71,8 @@
   let undo = $state(null);
   const archiveFlash = timedFlag(4000, () => (undo = null));
   let savedViews = $state([]);
+  let configuredRepos = $state([]);
+  let repoFilter = $state("");
   let pollIntervalS = $state(180);
   const inboxMountedAt = Date.now();
 
@@ -77,9 +80,11 @@
     try {
       const settings = await fetchSettings();
       savedViews = JSON.parse(settings.saved_views || "[]");
+      configuredRepos = settings.repos.split(",").map((repo) => repo.trim()).filter(Boolean);
       pollIntervalS = Number.isFinite(settings.poll_interval_s) ? settings.poll_interval_s : 180;
     } catch {
       savedViews = [];
+      configuredRepos = [];
     }
   }
 
@@ -271,7 +276,7 @@
       const selectedKey = view === "closed" && ordered[selected] ? prKey(ordered[selected]) : null;
       closedPrs = res.prs;
       if (selectedKey !== null) {
-        const idx = closedPrs.findIndex((pr) => prKey(pr) === selectedKey);
+        const idx = filterByRepository(closedPrs, repoFilter).findIndex((pr) => prKey(pr) === selectedKey);
         if (idx >= 0) selected = idx;
       }
     } catch {
@@ -320,7 +325,11 @@
   });
 
   let historyActive = $derived(wantsHistory(filterQuery) && historyQuery === filterQuery.trim() && !historyLoading);
-  let filteredPrs = $derived(wantsHistory(filterQuery) ? (historyQuery === filterQuery.trim() ? historyPrs : []) : filterPrs(prs, filterQuery, showArchived));
+  let queryFilteredPrs = $derived(wantsHistory(filterQuery) ? (historyQuery === filterQuery.trim() ? historyPrs : []) : filterPrs(prs, filterQuery, showArchived));
+  let availableRepos = $derived(availableRepositories(configuredRepos, prs, archivedPrs, closedPrs));
+  let filteredPrs = $derived(filterByRepository(queryFilteredPrs, repoFilter));
+  let filteredClosedPrs = $derived(filterByRepository(closedPrs, repoFilter));
+  let actionsHref = $derived(`#/actions?repo=${encodeURIComponent(repoFilter)}`);
   let activeView = $derived(savedViews.find((v) => v.query === filterQuery.trim())?.name ?? null);
 
   // history views can't be counted from the open inbox; show the live count only while applied, else a placeholder
@@ -532,7 +541,7 @@
     const pr = prs.find((p) => prKey(p) === dragKey);
     return pr ? (pr.rank != null ? "pinned" : classify(topUnit(pr), viewerLogin).group) : null;
   });
-  let ordered = $derived(view === "closed" ? closedPrs : showArchived ? [...openOrdered, ...archivedPrs] : openOrdered);
+  let ordered = $derived(view === "closed" ? filteredClosedPrs : showArchived ? [...openOrdered, ...archivedPrs] : openOrdered);
   let archivedSet = $derived(new Set(archivedPrs.map((pr) => prKey(pr))));
   const isArchived = (pr) => archivedSet.has(prKey(pr));
 
@@ -796,16 +805,27 @@
     </header>
 
 
-    <div class="view-tabs" role="tablist" aria-label="List view">
-      <button class="view-tab" role="tab" aria-selected={view === "open"} class:active={view === "open"} onclick={() => showView("open")}>
-        Open
-        <span class="view-tab-count">{prs.length}</span>
-        {#if view === "closed"}<Kbd keys="tab" />{/if}
-      </button>
-      <button class="view-tab" role="tab" aria-selected={view === "closed"} class:active={view === "closed"} onclick={() => showView("closed")}>
-        Recently merged {#if view === "open"}<Kbd keys="tab" />{/if}
-      </button>
-      <a class="view-tab" role="tab" aria-selected="false" href="#/actions">Actions</a>
+    <div class="queue-toolbar">
+      <div class="view-tabs" role="tablist" aria-label="List view">
+        <button class="view-tab" role="tab" aria-selected={view === "open"} class:active={view === "open"} onclick={() => showView("open")}>
+          Open
+          <span class="view-tab-count">{filterByRepository(prs, repoFilter).length}</span>
+          {#if view === "closed"}<Kbd keys="tab" />{/if}
+        </button>
+        <button class="view-tab" role="tab" aria-selected={view === "closed"} class:active={view === "closed"} onclick={() => showView("closed")}>
+          Recently merged {#if view === "open"}<Kbd keys="tab" />{/if}
+        </button>
+        <a class="view-tab" role="tab" aria-selected="false" href={actionsHref}>Actions</a>
+      </div>
+      <label class="repo-filter">
+        <span>Repository</span>
+        <select bind:value={repoFilter} onchange={() => (selected = 0)} aria-label="Filter by repository">
+          <option value="">All repositories</option>
+          {#each availableRepos as repo}
+            <option value={repo}>{repo}</option>
+          {/each}
+        </select>
+      </label>
     </div>
 
     {#if filterOpen && view === "open"}
@@ -983,10 +1003,12 @@
             <div class="empty">Loading recent merges…</div>
           {:else if closedPrs.length === 0}
             <div class="empty">Nothing merged or closed yet</div>
+          {:else if filteredClosedPrs.length === 0}
+            <div class="empty">Nothing merged or closed in {repoFilter}</div>
           {/if}
           <section class="queue-group">
             <div class="group-body">
-              {#each closedPrs as pr (prKey(pr))}{@render closedRow(pr)}{/each}
+              {#each filteredClosedPrs as pr (prKey(pr))}{@render closedRow(pr)}{/each}
             </div>
           </section>
         {:else}
@@ -996,6 +1018,8 @@
             <div class="empty">Syncing with GitHub…</div>
           {:else if loaded && prs.length === 0}
             <div class="empty">No open pull requests</div>
+          {:else if repoFilter && filteredPrs.length === 0}
+            <div class="empty">No open pull requests in {repoFilter}</div>
           {:else if wantsHistory(filterQuery) && !historyActive}
             <div class="empty">Searching history…</div>
           {:else if filterQuery && filteredPrs.length === 0}
@@ -1582,12 +1606,36 @@
   .view-tabs {
     display: flex;
     gap: 4px;
-    margin: 0 0 16px;
+    margin: 0;
     padding: 3px;
     background: var(--panel);
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-xs);
+  }
+  .queue-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .repo-filter {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+    color: var(--text-dim);
+    font-size: 12px;
+  }
+  .repo-filter select {
+    min-height: 36px;
+    max-width: 280px;
+    padding: 0 34px 0 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--panel);
+    color: var(--text);
+    font: 12px var(--sans);
   }
   .view-tab {
     display: flex;
@@ -1971,6 +2019,28 @@
     background: transparent;
     box-shadow: none;
   }
+  .queue-toolbar .view-tabs {
+    margin: 0;
+  }
+  .queue-toolbar {
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+  .repo-filter {
+    margin-left: auto;
+    font-size: 14px;
+  }
+  .repo-filter select {
+    min-height: 32px;
+    max-width: 260px;
+    padding: 0 32px 0 12px;
+    border: 0;
+    border-radius: 999px;
+    background-color: var(--panel);
+    box-shadow: var(--shadow-control-outlined);
+    color: var(--text);
+    font: 500 14px var(--sans);
+  }
   .view-tab {
     min-height: 32px;
     padding: 0 12px;
@@ -2277,6 +2347,19 @@
     }
     .view-tab :global(.kbd) {
       display: none;
+    }
+    .queue-toolbar {
+      align-items: stretch;
+      flex-direction: column;
+    }
+    .repo-filter {
+      align-items: stretch;
+      flex-direction: column;
+      margin-left: 0;
+    }
+    .repo-filter select {
+      width: 100%;
+      max-width: none;
     }
     .row {
       display: grid;

--- a/ui/src/lib/Inbox.svelte
+++ b/ui/src/lib/Inbox.svelte
@@ -19,11 +19,12 @@
   import UpdateButton from "./UpdateButton.svelte";
   import { timedFlag } from "./timedFlag.svelte.js";
   import { prKey } from "./prKey.js";
-  import { availableRepositories, filterByRepository } from "./repoFilter.js";
+  import { availableRepositories, filterByRepositories } from "./repoFilter.js";
   import { showFlash } from "./flash.svelte.js";
   import CurrentBranchBadge from "./CurrentBranchBadge.svelte";
   import Kbd from "./Kbd.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
+  import MultiSelectDropdown from "./MultiSelectDropdown.svelte";
 
   let { active = true, refreshRevision = 0, pollCompletedAt = null, onFindPr = () => {} } = $props();
   let handledRefreshRevision = refreshRevision;
@@ -70,9 +71,19 @@
   let closedSeq = 0;
   let undo = $state(null);
   const archiveFlash = timedFlag(4000, () => (undo = null));
+  function storedRepositories() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem("cockpit:repository-scope") ?? "[]");
+      return Array.isArray(parsed) ? parsed.filter((repo) => typeof repo === "string" && repo) : [];
+    } catch {
+      return [];
+    }
+  }
+
   let savedViews = $state([]);
   let configuredRepos = $state([]);
-  let repoFilter = $state("");
+  let selectedRepos = $state(storedRepositories());
+  let repoPickerOpen = $state(false);
   let pollIntervalS = $state(180);
   const inboxMountedAt = Date.now();
 
@@ -86,6 +97,13 @@
       savedViews = [];
       configuredRepos = [];
     }
+  }
+
+  function selectRepositories(repos) {
+    selectedRepos = [...repos];
+    if (repos.length) localStorage.setItem("cockpit:repository-scope", JSON.stringify(repos));
+    else localStorage.removeItem("cockpit:repository-scope");
+    selected = 0;
   }
 
   async function persistViews(views) {
@@ -276,7 +294,7 @@
       const selectedKey = view === "closed" && ordered[selected] ? prKey(ordered[selected]) : null;
       closedPrs = res.prs;
       if (selectedKey !== null) {
-        const idx = filterByRepository(closedPrs, repoFilter).findIndex((pr) => prKey(pr) === selectedKey);
+        const idx = filterByRepositories(closedPrs, selectedRepos).findIndex((pr) => prKey(pr) === selectedKey);
         if (idx >= 0) selected = idx;
       }
     } catch {
@@ -327,9 +345,14 @@
   let historyActive = $derived(wantsHistory(filterQuery) && historyQuery === filterQuery.trim() && !historyLoading);
   let queryFilteredPrs = $derived(wantsHistory(filterQuery) ? (historyQuery === filterQuery.trim() ? historyPrs : []) : filterPrs(prs, filterQuery, showArchived));
   let availableRepos = $derived(availableRepositories(configuredRepos, prs, archivedPrs, closedPrs));
-  let filteredPrs = $derived(filterByRepository(queryFilteredPrs, repoFilter));
-  let filteredClosedPrs = $derived(filterByRepository(closedPrs, repoFilter));
-  let actionsHref = $derived(`#/actions?repo=${encodeURIComponent(repoFilter)}`);
+  let filteredPrs = $derived(filterByRepositories(queryFilteredPrs, selectedRepos));
+  let filteredClosedPrs = $derived(filterByRepositories(closedPrs, selectedRepos));
+  let actionsHref = $derived.by(() => {
+    const params = new URLSearchParams();
+    if (selectedRepos.length === 0) params.append("repo", "");
+    else for (const repo of selectedRepos) params.append("repo", repo);
+    return `#/actions?${params}`;
+  });
   let activeView = $derived(savedViews.find((v) => v.query === filterQuery.trim())?.name ?? null);
 
   // history views can't be counted from the open inbox; show the live count only while applied, else a placeholder
@@ -674,6 +697,11 @@
         e.preventDefault();
         return;
       }
+      if (e.key === "Escape" && repoPickerOpen) {
+        repoPickerOpen = false;
+        e.preventDefault();
+        return;
+      }
       if (e.key === "Escape" && filterOpen) {
         closeFilter();
         e.preventDefault();
@@ -686,6 +714,11 @@
       }
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (isTypingTarget(e.target)) return;
+      if (e.key === "r") {
+        repoPickerOpen = !repoPickerOpen;
+        e.preventDefault();
+        return;
+      }
       if (e.key === "/") {
         openFilter();
         e.preventDefault();
@@ -809,7 +842,7 @@
       <div class="view-tabs" role="tablist" aria-label="List view">
         <button class="view-tab" role="tab" aria-selected={view === "open"} class:active={view === "open"} onclick={() => showView("open")}>
           Open
-          <span class="view-tab-count">{filterByRepository(prs, repoFilter).length}</span>
+          <span class="view-tab-count">{filterByRepositories(prs, selectedRepos).length}</span>
           {#if view === "closed"}<Kbd keys="tab" />{/if}
         </button>
         <button class="view-tab" role="tab" aria-selected={view === "closed"} class:active={view === "closed"} onclick={() => showView("closed")}>
@@ -817,15 +850,17 @@
         </button>
         <a class="view-tab" role="tab" aria-selected="false" href={actionsHref}>Actions</a>
       </div>
-      <label class="repo-filter">
-        <span>Repository</span>
-        <select bind:value={repoFilter} onchange={() => (selected = 0)} aria-label="Filter by repository">
-          <option value="">All repositories</option>
-          {#each availableRepos as repo}
-            <option value={repo}>{repo}</option>
-          {/each}
-        </select>
-      </label>
+      <div class="repo-filter">
+        <MultiSelectDropdown
+          label="Repository"
+          options={availableRepos}
+          selected={selectedRepos}
+          plural="repositories"
+          keybind="r"
+          bind:open={repoPickerOpen}
+          onchange={selectRepositories}
+        />
+      </div>
     </div>
 
     {#if filterOpen && view === "open"}
@@ -1004,7 +1039,7 @@
           {:else if closedPrs.length === 0}
             <div class="empty">Nothing merged or closed yet</div>
           {:else if filteredClosedPrs.length === 0}
-            <div class="empty">Nothing merged or closed in {repoFilter}</div>
+            <div class="empty">Nothing merged or closed in the selected repositories</div>
           {/if}
           <section class="queue-group">
             <div class="group-body">
@@ -1018,8 +1053,8 @@
             <div class="empty">Syncing with GitHub…</div>
           {:else if loaded && prs.length === 0}
             <div class="empty">No open pull requests</div>
-          {:else if repoFilter && filteredPrs.length === 0}
-            <div class="empty">No open pull requests in {repoFilter}</div>
+          {:else if selectedRepos.length && filteredPrs.length === 0}
+            <div class="empty">No open pull requests in the selected repositories</div>
           {:else if wantsHistory(filterQuery) && !historyActive}
             <div class="empty">Searching history…</div>
           {:else if filterQuery && filteredPrs.length === 0}
@@ -1620,22 +1655,7 @@
     margin-bottom: 16px;
   }
   .repo-filter {
-    display: flex;
-    align-items: center;
-    gap: 8px;
     margin-left: auto;
-    color: var(--text-dim);
-    font-size: 12px;
-  }
-  .repo-filter select {
-    min-height: 36px;
-    max-width: 280px;
-    padding: 0 34px 0 12px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    background: var(--panel);
-    color: var(--text);
-    font: 12px var(--sans);
   }
   .view-tab {
     display: flex;
@@ -2026,21 +2046,6 @@
     gap: 10px;
     margin-bottom: 20px;
   }
-  .repo-filter {
-    margin-left: auto;
-    font-size: 14px;
-  }
-  .repo-filter select {
-    min-height: 32px;
-    max-width: 260px;
-    padding: 0 32px 0 12px;
-    border: 0;
-    border-radius: 999px;
-    background-color: var(--panel);
-    box-shadow: var(--shadow-control-outlined);
-    color: var(--text);
-    font: 500 14px var(--sans);
-  }
   .view-tab {
     min-height: 32px;
     padding: 0 12px;
@@ -2353,13 +2358,8 @@
       flex-direction: column;
     }
     .repo-filter {
-      align-items: stretch;
-      flex-direction: column;
-      margin-left: 0;
-    }
-    .repo-filter select {
       width: 100%;
-      max-width: none;
+      margin-left: 0;
     }
     .row {
       display: grid;

--- a/ui/src/lib/MultiSelectDropdown.svelte
+++ b/ui/src/lib/MultiSelectDropdown.svelte
@@ -1,10 +1,10 @@
 <script>
   import { tick } from "svelte";
   import { fuzzyMatch } from "./fuzzy.js";
+  import Kbd from "./Kbd.svelte";
 
-  let { label, options = [], selected = [], plural, onchange } = $props();
+  let { label, options = [], selected = [], plural, onchange, keybind = null, open = $bindable(false) } = $props();
 
-  let open = $state(false);
   let root = $state(null);
   let menu = $state(null);
   let input = $state(null);
@@ -139,8 +139,11 @@
       }
     }}
   >
-    <span>{buttonLabel}</span>
-    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m4 6 4 4 4-4"></path></svg>
+    <span class="trigger-label">{buttonLabel}</span>
+    <span class="trigger-tail">
+      {#if keybind}<Kbd keys={keybind} />{/if}
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m4 6 4 4 4-4"></path></svg>
+    </span>
   </button>
 
   {#if open}
@@ -192,7 +195,8 @@
   .field-label { color: var(--text-faint); font-size: 11px; }
   .trigger { display: flex; width: 176px; height: 30px; min-width: 0; padding: 0 8px 0 10px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid var(--border); border-radius: 6px; color: var(--text); background: var(--panel); font: 500 12px var(--sans); cursor: pointer; }
   .trigger:hover, .trigger[aria-expanded="true"] { border-color: var(--border-strong); background: var(--panel-raised); }
-  .trigger > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .trigger-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .trigger-tail { display: flex; flex: none; align-items: center; gap: 6px; }
   .trigger svg { width: 14px; height: 14px; flex: none; fill: none; stroke: var(--text-faint); stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.5; }
   .menu { position: absolute; z-index: 40; top: calc(100% + 6px); right: 0; width: 260px; max-height: 340px; overflow-y: auto; padding: 5px; border: 1px solid var(--border); border-radius: 8px; background: var(--panel-raised); box-shadow: var(--shadow-lg); }
   .search-wrap { display: flex; min-width: 0; padding: 2px 2px 5px; align-items: center; gap: 6px; }

--- a/ui/src/lib/repoFilter.js
+++ b/ui/src/lib/repoFilter.js
@@ -2,4 +2,4 @@ export function availableRepositories(configured, ...lists) {
   return [...new Set([...configured, ...lists.flat().map((pr) => pr.repo)].filter(Boolean))].sort();
 }
 
-export const filterByRepository = (prs, repo) => repo ? prs.filter((pr) => pr.repo === repo) : prs;
+export const filterByRepositories = (prs, repos) => repos.length ? prs.filter((pr) => repos.includes(pr.repo)) : prs;

--- a/ui/src/lib/repoFilter.js
+++ b/ui/src/lib/repoFilter.js
@@ -1,0 +1,5 @@
+export function availableRepositories(configured, ...lists) {
+  return [...new Set([...configured, ...lists.flat().map((pr) => pr.repo)].filter(Boolean))].sort();
+}
+
+export const filterByRepository = (prs, repo) => repo ? prs.filter((pr) => pr.repo === repo) : prs;

--- a/ui/src/lib/repoFilter.test.js
+++ b/ui/src/lib/repoFilter.test.js
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { availableRepositories, filterByRepository } from "./repoFilter.js";
+
+test("repository choices include configured and cached repositories", () => {
+  const prs = [{ repo: "example/app" }, { repo: "example/api" }];
+  expect(availableRepositories(["example/empty", "example/app"], prs)).toEqual([
+    "example/api",
+    "example/app",
+    "example/empty",
+  ]);
+  expect(filterByRepository(prs, "example/app")).toEqual([{ repo: "example/app" }]);
+  expect(filterByRepository(prs, "")).toBe(prs);
+});

--- a/ui/src/lib/repoFilter.test.js
+++ b/ui/src/lib/repoFilter.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { availableRepositories, filterByRepository } from "./repoFilter.js";
+import { availableRepositories, filterByRepositories } from "./repoFilter.js";
 
 test("repository choices include configured and cached repositories", () => {
   const prs = [{ repo: "example/app" }, { repo: "example/api" }];
@@ -8,6 +8,7 @@ test("repository choices include configured and cached repositories", () => {
     "example/app",
     "example/empty",
   ]);
-  expect(filterByRepository(prs, "example/app")).toEqual([{ repo: "example/app" }]);
-  expect(filterByRepository(prs, "")).toBe(prs);
+  expect(filterByRepositories(prs, ["example/app"])).toEqual([{ repo: "example/app" }]);
+  expect(filterByRepositories(prs, ["example/app", "example/api"])).toEqual(prs);
+  expect(filterByRepositories(prs, [])).toBe(prs);
 });


### PR DESCRIPTION
The inbox can aggregate several repositories, but its primary views do not share a repository scope. Open, Recently merged, and Actions can therefore show unrelated repositories or restore different persisted filters.

## What changed

- Build repository choices from configured repositories plus cached open, archived, and recently closed PRs.
- Apply one selection to Open rows, the Open count, Recently merged, and repository-specific empty states.
- Carry the selected repository into the existing Actions URL filter.
- Keep the picker right-aligned on desktop and full-width on phone layouts.
- Preserve the current pinned-group and accelerated Inbox behavior from upstream.

## Verification

- `bun test ui/src/lib/repoFilter.test.js` — 1 passed.
- `cd ui && bun run build`.
- Browser flow selects `fixture/admin-cockpit`, reduces Open to one row, scopes Recently merged, and opens Actions with the same repository selected.
- Desktop proof uses `1600×1200`; phone proof uses `390×844`.

## Screenshots

| Before | After |
|---|---|
| ![Multi-repository inbox without a repository scope control](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/repository/before.png) | ![Inbox filtered to one repository with a right-aligned picker](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/repository/after.png) |

### Phone

![Repository scope picker reflowed for a phone viewport](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/repository/phone.png)

## Defaults

- [ ] New functionality is off by default, if applicable. Repository scope is an always-available control for multi-repository Cockpits; it adds no service or mutation.
- [x] Styling is opt-in, or this is minor polish that preserves the default appearance. The control reuses existing tab and input geometry.
