### PR TITLE
fix(ui): keep shortcut footer clear of navigation

### DIFF
--- a/ui/src/lib/KeyBar.svelte
+++ b/ui/src/lib/KeyBar.svelte
@@ -18,7 +18,7 @@
 <style>
   .keybar {
     position: fixed;
-    left: 0;
+    left: var(--app-rail-width, 0px);
     right: 0;
     bottom: 0;
     height: 38px;


### PR DESCRIPTION
The fixed keyboard shortcut bar starts at the window edge while the desktop navigation rail occupies the same space. It can therefore cover the bottom of the sidebar and visually join two unrelated surfaces.

## What changed

- Start `KeyBar` at `--app-rail-width` instead of `0`.
- Preserve its existing content, overflow behavior, notification clearance, and phone hiding rule.
- Leave sidebar-hidden layouts unchanged because their rail width is already `0px`.

## Verification

- `cd ui && bun run build`.
- Computed geometry changes from `left: 0px` to `left: 216px`, exactly matching the desktop rail.

## Screenshots

| Before | After |
|---|---|
| ![Shortcut footer extending underneath the navigation rail](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/footer/before.png) | ![Shortcut footer constrained to the application content area](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/footer/after.png) |

## Defaults

- [x] New functionality is off by default, if applicable. This changes no functionality.
- [x] Styling is opt-in, or this is minor polish that preserves the default appearance. This is a one-line layout correction.
