### PR TITLE
feat(tailscale): publish Cockpit with Serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Settings live in the app. Optional shell overrides live in `~/.config/pr-cockpit
 | `COCKPIT_DEFAULT_REPO` | Repository assumed when a PR number is passed alone |
 | `COCKPIT_REPO_ROOTS` | Paths containing local checkouts |
 | `COCKPIT_RELAY_URL` | [Self-hosted webhook relay](docs/self-host-relay.md) |
+| `COCKPIT_TAILSCALE_SERVE` | Set to `1` to publish Cockpit privately through Tailscale Serve |
+| `COCKPIT_TAILSCALE_HTTPS_PORT` | Tailscale HTTPS port; defaults to `443` |
 
 </details>
 

--- a/scripts/cockpit
+++ b/scripts/cockpit
@@ -47,6 +47,8 @@ env_relay_url="${COCKPIT_RELAY_URL:-}"
 env_review_bots="${COCKPIT_REVIEW_BOTS:-}"
 env_proxy="${COCKPIT_PROXY:-}"
 env_proxy_port="${COCKPIT_PROXY_PORT:-}"
+env_tailscale_serve="${COCKPIT_TAILSCALE_SERVE:-}"
+env_tailscale_https_port="${COCKPIT_TAILSCALE_HTTPS_PORT:-}"
 
 if [[ "$platform" == "Linux" ]]; then
   config_file="${XDG_CONFIG_HOME:-$HOME/.config}/pr-cockpit/config"
@@ -61,6 +63,14 @@ fi
 port="${env_port:-${COCKPIT_PORT:-4820}}"
 url="http://127.0.0.1:$port"
 proxy_port="${env_proxy_port:-${COCKPIT_PROXY_PORT:-4820}}"
+tailscale_serve="${env_tailscale_serve:-${COCKPIT_TAILSCALE_SERVE:-}}"
+if [[ -n "$tailscale_serve" ]]; then
+  export COCKPIT_TAILSCALE_SERVE="$tailscale_serve"
+fi
+tailscale_https_port="${env_tailscale_https_port:-${COCKPIT_TAILSCALE_HTTPS_PORT:-}}"
+if [[ -n "$tailscale_https_port" ]]; then
+  export COCKPIT_TAILSCALE_HTTPS_PORT="$tailscale_https_port"
+fi
 if [[ "$platform" == "Linux" ]]; then
   data_dir="${env_data_dir:-${COCKPIT_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/pr-cockpit}}"
 else

--- a/scripts/install
+++ b/scripts/install
@@ -191,6 +191,14 @@ install_proxy="${install_proxy_env:-${COCKPIT_PROXY:-}}"
 install_proxy_port="${install_proxy_port_env:-${COCKPIT_PROXY_PORT:-4820}}"
 install_tailscale_serve="${install_tailscale_serve_env:-${COCKPIT_TAILSCALE_SERVE:-}}"
 install_tailscale_https_port="${install_tailscale_https_port_env:-${COCKPIT_TAILSCALE_HTTPS_PORT:-}}"
+install_tailscale_plist_args=""
+if [[ "$install_tailscale_serve" == "1" ]]; then
+  install_tailscale_plist_args="    <string>COCKPIT_TAILSCALE_SERVE=1</string>"
+  if [[ -n "$install_tailscale_https_port" ]]; then
+    install_tailscale_plist_args="$install_tailscale_plist_args
+    <string>COCKPIT_TAILSCALE_HTTPS_PORT=$install_tailscale_https_port</string>"
+  fi
+fi
 install_proxy="${install_proxy#ssh://}"
 install_proxy="${install_proxy%/}"
 
@@ -242,8 +250,7 @@ cat > "$server_agent_plist" <<PLIST
     <string>COCKPIT_TMUX_HOSTS=$install_tmux_hosts</string>
     <string>COCKPIT_REPLICA_SSH_HOST=$install_proxy</string>
     <string>COCKPIT_PROXY_PORT=$install_proxy_port</string>
-    <string>COCKPIT_TAILSCALE_SERVE=$install_tailscale_serve</string>
-    <string>COCKPIT_TAILSCALE_HTTPS_PORT=$install_tailscale_https_port</string>
+$install_tailscale_plist_args
     <string>COCKPIT_NO_BUILD=1</string>
     <string>COCKPIT_LAUNCHER=$runtime_launcher</string>
     <string>XDG_DATA_HOME=$xdg_data_home</string>

--- a/scripts/install
+++ b/scripts/install
@@ -162,6 +162,8 @@ if [[ ! -f "$config_file" ]]; then
 # COCKPIT_PORT=4820
 # COCKPIT_PROXY="build-server"      # optional Cockpit replica source over SSH
 # COCKPIT_PROXY_PORT=4820           # Cockpit port on the SSH host
+# COCKPIT_TAILSCALE_SERVE=1         # publish loopback over Tailscale Serve (never Funnel)
+# COCKPIT_TAILSCALE_HTTPS_PORT=8443 # HTTPS port for node Serve; 443 by default
 # COCKPIT_DEFAULT_REPO="owner/repo"
 # COCKPIT_TMUX_HOSTS="builder,build-vm"
 # COCKPIT_RELAY_URL="https://my-relay.example.workers.dev"
@@ -177,6 +179,8 @@ install_port_env="${COCKPIT_PORT:-}"
 install_tmux_hosts_env="${COCKPIT_TMUX_HOSTS:-}"
 install_proxy_env="${COCKPIT_PROXY:-}"
 install_proxy_port_env="${COCKPIT_PROXY_PORT:-}"
+install_tailscale_serve_env="${COCKPIT_TAILSCALE_SERVE:-}"
+install_tailscale_https_port_env="${COCKPIT_TAILSCALE_HTTPS_PORT:-}"
 if [[ -f "$config_file" ]]; then
   # shellcheck disable=SC1090
   source "$config_file"
@@ -185,6 +189,8 @@ install_port="${install_port_env:-${COCKPIT_PORT:-4820}}"
 install_tmux_hosts="${install_tmux_hosts_env:-${COCKPIT_TMUX_HOSTS:-}}"
 install_proxy="${install_proxy_env:-${COCKPIT_PROXY:-}}"
 install_proxy_port="${install_proxy_port_env:-${COCKPIT_PROXY_PORT:-4820}}"
+install_tailscale_serve="${install_tailscale_serve_env:-${COCKPIT_TAILSCALE_SERVE:-}}"
+install_tailscale_https_port="${install_tailscale_https_port_env:-${COCKPIT_TAILSCALE_HTTPS_PORT:-}}"
 install_proxy="${install_proxy#ssh://}"
 install_proxy="${install_proxy%/}"
 
@@ -236,6 +242,8 @@ cat > "$server_agent_plist" <<PLIST
     <string>COCKPIT_TMUX_HOSTS=$install_tmux_hosts</string>
     <string>COCKPIT_REPLICA_SSH_HOST=$install_proxy</string>
     <string>COCKPIT_PROXY_PORT=$install_proxy_port</string>
+    <string>COCKPIT_TAILSCALE_SERVE=$install_tailscale_serve</string>
+    <string>COCKPIT_TAILSCALE_HTTPS_PORT=$install_tailscale_https_port</string>
     <string>COCKPIT_NO_BUILD=1</string>
     <string>COCKPIT_LAUNCHER=$runtime_launcher</string>
     <string>XDG_DATA_HOME=$xdg_data_home</string>

--- a/scripts/install-linux.test.ts
+++ b/scripts/install-linux.test.ts
@@ -193,6 +193,17 @@ describe("transactional Linux lifecycle", () => {
     }
     expect(existsSync(join(f.dataHome, "pr-cockpit-runtime"))).toBe(false);
   });
+  test("persists an opt-in Tailscale Serve environment", async () => {
+    const f = fixture();
+    const result = await f.lifecycle(["install", f.source], {
+      COCKPIT_TAILSCALE_SERVE: "1",
+      COCKPIT_TAILSCALE_HTTPS_PORT: "8443",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(join(f.configHome, "pr-cockpit/server.env"), "utf8")).toContain(
+      "COCKPIT_TAILSCALE_SERVE=1\nCOCKPIT_TAILSCALE_HTTPS_PORT=\"8443\"\n",
+    );
+  }, 20_000);
   test("installs an immutable XDG release, exact desktop integration, and an ownership manifest without gh auth", async () => {
     const f = fixture();
     writeFileSync(join(f.source, "shared/desktopShortcuts.json"), "dirty worktree bytes");

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -124,6 +124,7 @@ test("new config is a commented inert example", async () => {
   expect(result.config).toContain('# COCKPIT_PROXY="build-server"');
   expect(result.config).not.toContain("Agents mutate existing PRs");
   expect(result.config).not.toMatch(/^[^#\n]*COCKPIT_PROXY=/m);
+  expect(result.serverPlist).not.toContain("COCKPIT_TAILSCALE");
 });
 
 test("a Tailscale Serve install persists the opt-in launch environment", async () => {

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -131,7 +131,7 @@ test("a Tailscale Serve install persists the opt-in launch environment", async (
   expect(result.exitCode).toBe(0);
   expect(result.serverPlist).toContain("<string>COCKPIT_TAILSCALE_SERVE=1</string>");
   expect(result.serverPlist).toContain("<string>COCKPIT_TAILSCALE_HTTPS_PORT=8443</string>");
-});
+}, 10_000);
 
 test("an app registration left behind by another root is replaced", async () => {
   const result = await install("/tmp/some-other-checkout");

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -64,7 +64,7 @@ exit 0`,
 
 async function install(
   loadedRoot: string | null,
-  options: { platform?: "Darwin" | "Linux"; proxy?: string; healthRoot?: string } = {},
+  options: { platform?: "Darwin" | "Linux"; proxy?: string; healthRoot?: string; tailscalePort?: string } = {},
 ) {
   const home = mkdtempSync(join(tmpdir(), "cockpit-install-"));
   try {
@@ -76,6 +76,10 @@ async function install(
         HOME: installHome,
         COCKPIT_PORT: "4820",
         ...(options.proxy ? { COCKPIT_PROXY: options.proxy } : {}),
+        ...(options.tailscalePort ? {
+          COCKPIT_TAILSCALE_SERVE: "1",
+          COCKPIT_TAILSCALE_HTTPS_PORT: options.tailscalePort,
+        } : {}),
       },
       stdout: "pipe",
       stderr: "pipe",
@@ -120,6 +124,13 @@ test("new config is a commented inert example", async () => {
   expect(result.config).toContain('# COCKPIT_PROXY="build-server"');
   expect(result.config).not.toContain("Agents mutate existing PRs");
   expect(result.config).not.toMatch(/^[^#\n]*COCKPIT_PROXY=/m);
+});
+
+test("a Tailscale Serve install persists the opt-in launch environment", async () => {
+  const result = await install(null, { tailscalePort: "8443" });
+  expect(result.exitCode).toBe(0);
+  expect(result.serverPlist).toContain("<string>COCKPIT_TAILSCALE_SERVE=1</string>");
+  expect(result.serverPlist).toContain("<string>COCKPIT_TAILSCALE_HTTPS_PORT=8443</string>");
 });
 
 test("an app registration left behind by another root is replaced", async () => {

--- a/scripts/linux-lifecycle.ts
+++ b/scripts/linux-lifecycle.ts
@@ -620,6 +620,8 @@ function installConfig(): void {
   const lines = [`COCKPIT_DATA_DIR=${quoteEnv(persistentData)}`, `COCKPIT_PORT=${configuredPort}`];
   if (process.env.COCKPIT_REPOS) lines.push(`COCKPIT_REPOS=${quoteEnv(process.env.COCKPIT_REPOS)}`);
   if (process.env.COCKPIT_ALLOWED_ORIGINS) lines.push(`COCKPIT_ALLOWED_ORIGINS=${quoteEnv(process.env.COCKPIT_ALLOWED_ORIGINS)}`);
+  if (process.env.COCKPIT_TAILSCALE_SERVE === "1") lines.push("COCKPIT_TAILSCALE_SERVE=1");
+  if (process.env.COCKPIT_TAILSCALE_HTTPS_PORT) lines.push(`COCKPIT_TAILSCALE_HTTPS_PORT=${quoteEnv(process.env.COCKPIT_TAILSCALE_HTTPS_PORT)}`);
   atomicFile(envFile, `${lines.join("\n")}\n`, 0o600);
 }
 function queryMime(): string | null {

--- a/server/cockpitServer.ts
+++ b/server/cockpitServer.ts
@@ -27,6 +27,15 @@ function parseAllowedOrigins(configured: string | undefined): Set<string> {
   return origins;
 }
 
+export function mergeRendererOrigins(...entries: Array<string | undefined | null>): string | undefined {
+  const origins = new Set<string>();
+  for (const entry of entries) {
+    if (!entry) continue;
+    for (const origin of parseAllowedOrigins(entry)) origins.add(origin);
+  }
+  return origins.size === 0 ? undefined : [...origins].join(",");
+}
+
 function buildOriginPolicy(configured: string | undefined): (request: Request) => boolean {
   const allowedOrigins = parseAllowedOrigins(configured);
   return (request) => {

--- a/server/http.ts
+++ b/server/http.ts
@@ -83,6 +83,7 @@ import {
   replicaStatus,
   replicaViewerLogin,
 } from "./replica.ts";
+import { tailscaleServeStatus } from "./tailscaleServe.ts";
 import type { GithubUsageSource } from "./githubUsage.ts";
 import type { GithubAuthStatus } from "./githubAuth.ts";
 import { commitsFromMirror, commitStatsFromMirror, conflictFilesFromMirror, diffFromMirror, fetchMirror, fileFromMirror, INCREMENTAL_FETCH_TIMEOUT_MS, materializePrWorktree, MirrorFetchError, summarizeCommitStats, type PullRequestCommit } from "./mirror.ts";
@@ -2546,7 +2547,14 @@ async function handleGithubAppCallback(url: URL): Promise<Response> {
 }
 
 function handleHealthz(): Response {
-  return json({ root: cockpitRoot, lastPollAt, prCount: countPrs(), replica: replicaEnabled() ? replicaStatus() : null });
+  const serve = tailscaleServeStatus();
+  return json({
+    root: cockpitRoot,
+    lastPollAt,
+    prCount: countPrs(),
+    replica: replicaEnabled() ? replicaStatus() : null,
+    ...(serve.enabled ? { tailscaleServe: serve } : {}),
+  });
 }
 
 function handleShutdown(): Response {

--- a/server/http.ts
+++ b/server/http.ts
@@ -2442,11 +2442,13 @@ const AGENT_PROMPT_DEFAULTS: Record<string, () => string> = {
 };
 
 function withAgentPromptDefaults(settings: Settings) {
+  const serve = tailscaleServeStatus();
   return {
     ...settings,
     agents: settings.agents.map((a) => ({ ...a, prompt_default: AGENT_PROMPT_DEFAULTS[a.id]?.() ?? "" })),
     agent_defaults: AGENT_DEFAULTS,
     harness_available: { claude: claudeBinPath() !== null, omp: ompBinPath() !== null, codex: codexBinPath() !== null },
+    ...(serve.enabled ? { tailscale_serve: serve } : {}),
   };
 }
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -10,10 +10,11 @@ import { startForwarders } from "./forwarders.ts";
 import { startWebhooks } from "./webhooks.ts";
 import { buildFetchHandler } from "./http.ts";
 import { installMockNetworkGuard, isMockGithub, seedMockDatabase } from "./mockGithub.ts";
-import { startCockpitServer } from "./cockpitServer.ts";
+import { mergeRendererOrigins, startCockpitServer } from "./cockpitServer.ts";
 import { ensureOmpInstalled } from "./commitMessage.ts";
 import { replicaEnabled, startReplicaSync } from "./replica.ts";
 import { captureFatal, startSentry } from "./sentry.ts";
+import { startTailscaleServe } from "./tailscaleServe.ts";
 
 const port = Number(Bun.env.COCKPIT_PORT ?? 4820);
 
@@ -32,7 +33,9 @@ try {
   }
 
   const fetchHandler = buildFetchHandler(port);
-  startCockpitServer(port, fetchHandler);
+  // Serve is opt-in and best-effort; a missing binary or failed publish must not block loopback.
+  const serve = await startTailscaleServe(port, isMockGithub ? { enabled: false } : {});
+  startCockpitServer(port, fetchHandler, mergeRendererOrigins(Bun.env.COCKPIT_ALLOWED_ORIGINS, serve.origin));
 
   if (!isMockGithub && !replicaEnabled()) {
     startForwarders(port);
@@ -45,6 +48,11 @@ try {
   }
   if (!isMockGithub) startUpdateCheck();
 
+  if (serve.enabled && serve.error) {
+    console.error(`pr-cockpit: Tailscale Serve failed (${serve.error}); loopback server is still running on http://127.0.0.1:${port}`);
+  } else if (serve.origin) {
+    console.log(`pr-cockpit: Tailscale Serve ${serve.origin} → http://127.0.0.1:${port}`);
+  }
   console.log(`pr-cockpit server listening on http://127.0.0.1:${port} (pid ${process.pid})`);
 } catch (err) {
   console.error(`pr-cockpit server failed to start on http://127.0.0.1:${port} (pid ${process.pid}):`, err);

--- a/server/tailscaleServe.test.ts
+++ b/server/tailscaleServe.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, expect, test } from "bun:test";
+import { mergeRendererOrigins, startCockpitServer } from "./cockpitServer.ts";
+import {
+  conflictingServeRoute,
+  magicDnsHttpsOrigin,
+  resetTailscaleServeStatus,
+  startTailscaleServe,
+  tailscaleHttpsPort,
+  tailscaleServeArgs,
+  tailscaleServeEnabled,
+  tailscaleServeStatus,
+  type TailscaleCommandResult,
+} from "./tailscaleServe.ts";
+import { setRendererInvalidationPublisher } from "./rendererInvalidation.ts";
+
+afterEach(resetTailscaleServeStatus);
+
+function fakeTailscale(commands: string[][]): (args: readonly string[]) => Promise<TailscaleCommandResult> {
+  return async (args) => {
+    commands.push([...args]);
+    if (args[0] === "status") {
+      return { exitCode: 0, stdout: JSON.stringify({ Self: { DNSName: "cockpit-node.example.ts.net." } }), stderr: "" };
+    }
+    if (args[0] === "serve" && args[1] === "status") return { exitCode: 0, stdout: JSON.stringify({ Web: {} }), stderr: "" };
+    if (args[0] === "serve" && args[1] === "--bg") return { exitCode: 0, stdout: "", stderr: "" };
+    return { exitCode: 1, stdout: "", stderr: `unexpected tailscale ${args.join(" ")}` };
+  };
+}
+
+test("Serve is opt-in", () => {
+  expect(tailscaleServeEnabled(undefined)).toBe(false);
+  expect(tailscaleServeEnabled("0")).toBe(false);
+  expect(tailscaleServeEnabled("1")).toBe(true);
+});
+
+test("Serve publishes configurable HTTPS to loopback and never Funnel", () => {
+  expect(tailscaleServeArgs(4820, 8443)).toEqual(["serve", "--bg", "--https=8443", "http://127.0.0.1:4820"]);
+  expect(tailscaleServeArgs(4820, 8443).join(" ")).not.toContain("funnel");
+  expect(tailscaleHttpsPort(undefined)).toBe(443);
+  expect(tailscaleHttpsPort("8443")).toBe(8443);
+  expect(() => tailscaleHttpsPort("0")).toThrow("not a valid port");
+});
+
+test("MagicDNS origin strips the trailing dot and includes a non-default port", () => {
+  const status = JSON.stringify({ Self: { DNSName: "cockpit-node.example.ts.net." } });
+  expect(magicDnsHttpsOrigin(status)).toBe("https://cockpit-node.example.ts.net");
+  expect(magicDnsHttpsOrigin(status, 8443)).toBe("https://cockpit-node.example.ts.net:8443");
+  expect(() => magicDnsHttpsOrigin("{}")).toThrow("did not report a MagicDNS name");
+});
+
+test("Serve records its published origin", async () => {
+  const commands: string[][] = [];
+  const status = await startTailscaleServe(4820, {
+    enabled: true,
+    httpsPort: 8443,
+    which: () => "/usr/bin/tailscale",
+    run: fakeTailscale(commands),
+  });
+  expect(status).toEqual({
+    enabled: true,
+    origin: "https://cockpit-node.example.ts.net:8443",
+    proxy: "http://127.0.0.1:4820",
+    httpsPort: 8443,
+    error: null,
+  });
+  expect(tailscaleServeStatus()).toEqual(status);
+  expect(commands).toEqual([
+    ["status", "--json"],
+    ["serve", "status", "--json"],
+    ["serve", "--bg", "--https=8443", "http://127.0.0.1:4820"],
+  ]);
+});
+
+test("Serve refuses to replace another root route", async () => {
+  const commands: string[][] = [];
+  const config = JSON.stringify({
+    Web: { "cockpit-node.example.ts.net:8443": { Handlers: { "/": { Proxy: "http://127.0.0.1:9999" } } } },
+  });
+  expect(conflictingServeRoute(config, "https://cockpit-node.example.ts.net:8443", 8443, "http://127.0.0.1:4820")).toContain("already routes /");
+  const status = await startTailscaleServe(4820, {
+    enabled: true,
+    httpsPort: 8443,
+    which: () => "/usr/bin/tailscale",
+    run: async (args) => {
+      commands.push([...args]);
+      if (args[0] === "status") return { exitCode: 0, stdout: JSON.stringify({ Self: { DNSName: "cockpit-node.example.ts.net." } }), stderr: "" };
+      return { exitCode: 0, stdout: config, stderr: "" };
+    },
+  });
+  expect(status.error).toContain("already routes /");
+  expect(commands).toEqual([["status", "--json"], ["serve", "status", "--json"]]);
+});
+
+test("missing Tailscale and failed status leave loopback available", async () => {
+  expect(await startTailscaleServe(4820, { enabled: true, which: () => null })).toEqual({
+    enabled: true, origin: null, proxy: "http://127.0.0.1:4820", httpsPort: 443, error: "`tailscale` is not on PATH",
+  });
+  expect(await startTailscaleServe(4820, {
+    enabled: true,
+    which: () => "/usr/bin/tailscale",
+    run: async () => ({ exitCode: 1, stdout: "", stderr: "tailscaled unavailable" }),
+  })).toEqual({
+    enabled: true, origin: null, proxy: "http://127.0.0.1:4820", httpsPort: 443, error: "tailscaled unavailable",
+  });
+  expect(await startTailscaleServe(4820, { enabled: false })).toEqual({
+    enabled: false, origin: null, proxy: null, httpsPort: null, error: null,
+  });
+});
+
+test("configured origins merge with the published Serve origin", () => {
+  expect(mergeRendererOrigins("https://other.example", "https://cockpit-node.example.ts.net:8443")).toBe(
+    "https://other.example,https://cockpit-node.example.ts.net:8443",
+  );
+  expect(mergeRendererOrigins(undefined, null)).toBeUndefined();
+});
+
+test("Cockpit server still listens only on loopback", () => {
+  const server = startCockpitServer(0, () => new Response("ok"));
+  try {
+    expect(server.hostname).toBe("127.0.0.1");
+  } finally {
+    server.stop(true);
+    setRendererInvalidationPublisher(() => {});
+  }
+});

--- a/server/tailscaleServe.ts
+++ b/server/tailscaleServe.ts
@@ -1,0 +1,159 @@
+export type TailscaleServeStatus = {
+  enabled: boolean;
+  origin: string | null;
+  proxy: string | null;
+  httpsPort: number | null;
+  error: string | null;
+};
+
+export type TailscaleCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type TailscaleCommandRunner = (args: readonly string[]) => Promise<TailscaleCommandResult>;
+
+const DISABLED: TailscaleServeStatus = { enabled: false, origin: null, proxy: null, httpsPort: null, error: null };
+const COMMAND_TIMEOUT_MS = 15_000;
+const HOSTNAME = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+let lastStatus: TailscaleServeStatus = DISABLED;
+
+export function tailscaleServeEnabled(value = Bun.env.COCKPIT_TAILSCALE_SERVE): boolean {
+  return value === "1";
+}
+
+export function tailscaleHttpsPort(value = Bun.env.COCKPIT_TAILSCALE_HTTPS_PORT): number {
+  const port = value?.trim() ? Number(value) : 443;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`COCKPIT_TAILSCALE_HTTPS_PORT is not a valid port: ${value}`);
+  }
+  return port;
+}
+
+export function tailscaleServeStatus(): TailscaleServeStatus {
+  return lastStatus;
+}
+
+export function resetTailscaleServeStatus(): void {
+  lastStatus = DISABLED;
+}
+
+function failed(proxy: string, httpsPort: number | null, error: string): TailscaleServeStatus {
+  return { enabled: true, origin: null, proxy, httpsPort, error };
+}
+
+function selfDnsName(status: unknown): string {
+  if (!status || typeof status !== "object" || !("Self" in status) || !status.Self || typeof status.Self !== "object") {
+    return "";
+  }
+  const dnsName = "DNSName" in status.Self ? status.Self.DNSName : "";
+  return typeof dnsName === "string" ? dnsName : "";
+}
+
+export function normalizeMagicDnsHost(value: string): string {
+  return value.trim().replace(/\.+$/, "").toLowerCase();
+}
+
+export function magicDnsHttpsOrigin(statusJson: string, httpsPort = 443): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(statusJson);
+  } catch {
+    throw new Error("tailscale status --json was not valid JSON");
+  }
+  const dnsName = selfDnsName(parsed);
+  const host = normalizeMagicDnsHost(dnsName);
+  if (!HOSTNAME.test(host)) {
+    throw new Error(host ? `Tailscale MagicDNS name is not a valid hostname: ${dnsName}` : "Tailscale did not report a MagicDNS name");
+  }
+  return `https://${host}${httpsPort === 443 ? "" : `:${httpsPort}`}`;
+}
+
+export function tailscaleServeArgs(port: number, httpsPort = 443): string[] {
+  return ["serve", "--bg", `--https=${httpsPort}`, `http://127.0.0.1:${port}`];
+}
+
+export function conflictingServeRoute(serveStatusJson: string, origin: string, httpsPort: number, proxy: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serveStatusJson);
+  } catch {
+    throw new Error("tailscale serve status --json was not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || !("Web" in parsed) || !parsed.Web || typeof parsed.Web !== "object") return null;
+  const host = new URL(origin).hostname;
+  const site = (parsed.Web as Record<string, unknown>)[`${host}:${httpsPort}`];
+  if (!site || typeof site !== "object" || !("Handlers" in site) || !site.Handlers || typeof site.Handlers !== "object") return null;
+  const handler = (site.Handlers as Record<string, unknown>)["/"];
+  if (!handler || typeof handler !== "object") return null;
+  const existing = "Proxy" in handler && typeof handler.Proxy === "string" ? handler.Proxy : "another handler";
+  return existing === proxy ? null : `Tailscale HTTPS ${httpsPort} already routes / to ${existing}`;
+}
+
+async function runTailscale(bin: string, args: readonly string[]): Promise<TailscaleCommandResult> {
+  const process = Bun.spawn([bin, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    signal: AbortSignal.timeout(COMMAND_TIMEOUT_MS),
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+export async function startTailscaleServe(
+  port: number,
+  deps: { enabled?: boolean; httpsPort?: number; which?: () => string | null; run?: TailscaleCommandRunner } = {},
+): Promise<TailscaleServeStatus> {
+  if (!(deps.enabled ?? tailscaleServeEnabled())) {
+    lastStatus = DISABLED;
+    return lastStatus;
+  }
+  const proxy = `http://127.0.0.1:${port}`;
+  let httpsPort: number;
+  try {
+    httpsPort = deps.httpsPort ?? tailscaleHttpsPort();
+  } catch (error) {
+    lastStatus = failed(proxy, null, error instanceof Error ? error.message : String(error));
+    return lastStatus;
+  }
+  const bin = (deps.which ?? (() => Bun.which("tailscale")))();
+  if (!bin) {
+    lastStatus = failed(proxy, httpsPort, "`tailscale` is not on PATH");
+    return lastStatus;
+  }
+  const run = deps.run ?? ((args) => runTailscale(bin, args));
+  try {
+    const status = await run(["status", "--json"]);
+    if (status.exitCode !== 0) {
+      lastStatus = failed(proxy, httpsPort, (status.stderr || status.stdout).trim() || `tailscale status exited ${status.exitCode}`);
+      return lastStatus;
+    }
+    const origin = magicDnsHttpsOrigin(status.stdout, httpsPort);
+    const serveStatus = await run(["serve", "status", "--json"]);
+    if (serveStatus.exitCode !== 0) {
+      lastStatus = failed(proxy, httpsPort, (serveStatus.stderr || serveStatus.stdout).trim() || `tailscale serve status exited ${serveStatus.exitCode}`);
+      return lastStatus;
+    }
+    const conflict = conflictingServeRoute(serveStatus.stdout, origin, httpsPort, proxy);
+    if (conflict) {
+      lastStatus = failed(proxy, httpsPort, conflict);
+      return lastStatus;
+    }
+    const served = await run(tailscaleServeArgs(port, httpsPort));
+    if (served.exitCode !== 0) {
+      lastStatus = failed(proxy, httpsPort, (served.stderr || served.stdout).trim() || `tailscale serve exited ${served.exitCode}`);
+      return lastStatus;
+    }
+    lastStatus = { enabled: true, origin, proxy, httpsPort, error: null };
+    return lastStatus;
+  } catch (error) {
+    lastStatus = failed(proxy, httpsPort, error instanceof Error ? error.message : String(error));
+    return lastStatus;
+  }
+}

--- a/ui/src/lib/Onboarding.svelte
+++ b/ui/src/lib/Onboarding.svelte
@@ -1,8 +1,9 @@
 <script>
-  import { fetchAuthStatus, fetchOnboardingRepos, fetchRelayCoverage, fetchSettings, refreshInbox, saveSettings } from "./api.js";
+  import { fetchAuthStatus, fetchHealth, fetchOnboardingRepos, fetchRelayCoverage, fetchSettings, refreshInbox, saveSettings } from "./api.js";
   import { relativeTime } from "./time.js";
   import Kbd from "./Kbd.svelte";
   import GithubSetupModal from "./GithubSetupModal.svelte";
+  import { tailscaleAccess } from "./tailscaleAccess.js";
 
   let { onDone, onCancel = null } = $props();
 
@@ -31,6 +32,8 @@
   let coverageTimer = null;
   let syncState = $state("idle");
   let syncError = $state(null);
+  let health = $state(null);
+  let privateAccess = $derived(tailscaleAccess(health));
 
   const configuredRepos = fetchSettings()
     .then((settings) => settings.repos.split(",").map((repo) => repo.trim()).filter(Boolean))
@@ -44,6 +47,7 @@
 
   $effect(() => {
     checkAuth();
+    fetchHealth().then((value) => (health = value)).catch(() => {});
   });
 
   $effect(() => () => clearTimeout(coverageTimer));
@@ -405,6 +409,14 @@
         </div>
       {:else if syncState === "complete"}
         <p class="ready-copy">Your inbox is ready.</p>
+        {#if privateAccess.state === "live"}
+          <div class="status-card">
+            <span class="status-mark success" aria-hidden="true">✓</span>
+            <span>Private on your tailnet at <a href={privateAccess.origin}>{privateAccess.origin}</a></span>
+          </div>
+        {:else if privateAccess.state === "error"}
+          <div class="notice failure-notice"><strong>Tailscale needs attention.</strong><span>{privateAccess.error}</span></div>
+        {/if}
       {/if}
 
       <div class="actions">

--- a/ui/src/lib/Onboarding.svelte
+++ b/ui/src/lib/Onboarding.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { fetchAuthStatus, fetchHealth, fetchOnboardingRepos, fetchRelayCoverage, fetchSettings, refreshInbox, saveSettings } from "./api.js";
+  import { fetchAuthStatus, fetchOnboardingRepos, fetchRelayCoverage, fetchSettings, refreshInbox, saveSettings } from "./api.js";
   import { relativeTime } from "./time.js";
   import Kbd from "./Kbd.svelte";
   import GithubSetupModal from "./GithubSetupModal.svelte";
@@ -36,7 +36,10 @@
   let privateAccess = $derived(tailscaleAccess(health));
 
   const configuredRepos = fetchSettings()
-    .then((settings) => settings.repos.split(",").map((repo) => repo.trim()).filter(Boolean))
+    .then((settings) => {
+      health = settings.tailscale_serve ? { tailscaleServe: settings.tailscale_serve } : null;
+      return settings.repos.split(",").map((repo) => repo.trim()).filter(Boolean);
+    })
     .catch(() => []);
 
   let chosen = $derived([...new Set([...manual, ...repos.filter((repo) => selected.has(repo.nameWithOwner)).map((repo) => repo.nameWithOwner)])]);
@@ -47,7 +50,6 @@
 
   $effect(() => {
     checkAuth();
-    fetchHealth().then((value) => (health = value)).catch(() => {});
   });
 
   $effect(() => () => clearTimeout(coverageTimer));
@@ -409,12 +411,12 @@
         </div>
       {:else if syncState === "complete"}
         <p class="ready-copy">Your inbox is ready.</p>
-        {#if privateAccess.state === "live"}
+        {#if privateAccess?.state === "live"}
           <div class="status-card">
             <span class="status-mark success" aria-hidden="true">✓</span>
             <span>Private on your tailnet at <a href={privateAccess.origin}>{privateAccess.origin}</a></span>
           </div>
-        {:else if privateAccess.state === "error"}
+        {:else if privateAccess?.state === "error"}
           <div class="notice failure-notice"><strong>Tailscale needs attention.</strong><span>{privateAccess.error}</span></div>
         {/if}
       {/if}

--- a/ui/src/lib/Settings.svelte
+++ b/ui/src/lib/Settings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { fetchHealth, fetchRelayCoverage, fetchRelayStatus, fetchSettings, saveSettings } from "./api.js";
+  import { fetchRelayCoverage, fetchRelayStatus, fetchSettings, saveSettings } from "./api.js";
   import { setCodeTheme, setFonts, setScales, setTheme } from "./theme.svelte.js";
   import { setPrefs } from "./prefs.svelte.js";
   import { BUILTIN_TEST_PATH } from "./testPath.js";
@@ -145,6 +145,7 @@
     keybindOpenPalette = s.keybind_open_palette;
     relayUrl = s.relay_url;
     testPathRegex = s.test_path_regex || BUILTIN_TEST_PATH.source;
+    health = s.tailscale_serve ? { tailscaleServe: s.tailscale_serve } : null;
   }
 
   let relayOrg = $derived(configuredRepos[0]?.split("/")[0] ?? "");
@@ -195,9 +196,6 @@
       .catch(() => {});
     fetchRelayCoverage()
       .then((c) => (relayCoverage = c))
-      .catch(() => {});
-    fetchHealth()
-      .then((value) => (health = value))
       .catch(() => {});
   });
 
@@ -326,17 +324,17 @@
         <button class="btn setup-again" type="button" onclick={onRunSetup}>Run setup again</button>
 
         <div class="settings-grid">
-          <div class="field field-wide private-access" class:private-access-live={privateAccess.state === "live"}>
-            <span class="label">Private access</span>
-            {#if privateAccess.state === "live"}
-              <span class="hint">Live through {privateAccess.kind}. The local server remains private on loopback.</span>
-              <a class="private-origin mono" href={privateAccess.origin}>{privateAccess.origin}</a>
-            {:else if privateAccess.state === "error"}
-              <span class="hint invalid-hint">Tailscale could not publish Cockpit: {privateAccess.error}</span>
-            {:else}
-              <span class="hint">Local only. Enable Tailscale Serve during installation to open Cockpit securely from your tailnet.</span>
-            {/if}
-          </div>
+          {#if privateAccess}
+            <div class="field field-wide private-access" class:private-access-live={privateAccess.state === "live"}>
+              <span class="label">Private access</span>
+              {#if privateAccess.state === "live"}
+                <span class="hint">Live through {privateAccess.kind}. The local server remains private on loopback.</span>
+                <a class="private-origin mono" href={privateAccess.origin}>{privateAccess.origin}</a>
+              {:else}
+                <span class="hint invalid-hint">Tailscale could not publish Cockpit: {privateAccess.error}</span>
+              {/if}
+            </div>
+          {/if}
 
           <label class="field field-wide">
             <span class="label">Repositories</span>

--- a/ui/src/lib/Settings.svelte
+++ b/ui/src/lib/Settings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { fetchRelayCoverage, fetchRelayStatus, fetchSettings, saveSettings } from "./api.js";
+  import { fetchHealth, fetchRelayCoverage, fetchRelayStatus, fetchSettings, saveSettings } from "./api.js";
   import { setCodeTheme, setFonts, setScales, setTheme } from "./theme.svelte.js";
   import { setPrefs } from "./prefs.svelte.js";
   import { BUILTIN_TEST_PATH } from "./testPath.js";
@@ -11,6 +11,7 @@
   import SettingsAnalytics from "./SettingsAnalytics.svelte";
   import { SETTINGS_SECTION_KEY, SETTINGS_SECTIONS, normalizeSettingsSection } from "./settingsSections.js";
   import { desktopShortcutDefaults, shortcutsClash } from "./shortcutPlatform.js";
+  import { tailscaleAccess } from "./tailscaleAccess.js";
   let { onRunSetup, section = "general" } = $props();
 
 
@@ -43,6 +44,7 @@
   let replicaSshHost = $state("");
   let relayInfo = $state(null);
   let relayCoverage = $state(null);
+  let health = $state(null);
   let loaded = $state(false);
   let saving = $state(false);
   let saved = $state(false);
@@ -50,6 +52,7 @@
 
   let activeTab = $derived(normalizeSettingsSection(section));
   let activeSection = $derived(SETTINGS_SECTIONS.find((item) => item.id === activeTab));
+  let privateAccess = $derived(tailscaleAccess(health));
 
   $effect(() => localStorage.setItem(SETTINGS_SECTION_KEY, activeTab));
 
@@ -193,6 +196,9 @@
     fetchRelayCoverage()
       .then((c) => (relayCoverage = c))
       .catch(() => {});
+    fetchHealth()
+      .then((value) => (health = value))
+      .catch(() => {});
   });
 
   async function save() {
@@ -320,6 +326,18 @@
         <button class="btn setup-again" type="button" onclick={onRunSetup}>Run setup again</button>
 
         <div class="settings-grid">
+          <div class="field field-wide private-access" class:private-access-live={privateAccess.state === "live"}>
+            <span class="label">Private access</span>
+            {#if privateAccess.state === "live"}
+              <span class="hint">Live through {privateAccess.kind}. The local server remains private on loopback.</span>
+              <a class="private-origin mono" href={privateAccess.origin}>{privateAccess.origin}</a>
+            {:else if privateAccess.state === "error"}
+              <span class="hint invalid-hint">Tailscale could not publish Cockpit: {privateAccess.error}</span>
+            {:else}
+              <span class="hint">Local only. Enable Tailscale Serve during installation to open Cockpit securely from your tailnet.</span>
+            {/if}
+          </div>
+
           <label class="field field-wide">
             <span class="label">Repositories</span>
             <span class="hint">One owner/name per line — watched for PRs involving you</span>
@@ -705,6 +723,19 @@
     border-radius: 8px;
     background: var(--fail-bg);
     margin-bottom: 22px;
+  }
+  .private-access {
+    padding: 14px;
+    border-radius: var(--radius-md);
+    background: var(--surface);
+  }
+  .private-access-live {
+    box-shadow: inset 3px 0 0 var(--ready);
+  }
+  .private-origin {
+    width: fit-content;
+    color: var(--link);
+    font-size: 12px;
   }
   .reset-link {
     display: block;

--- a/ui/src/lib/api.js
+++ b/ui/src/lib/api.js
@@ -327,6 +327,12 @@ export async function fetchSettings() {
   return settingsInFlight;
 }
 
+export async function fetchHealth() {
+  const res = await fetch("/healthz");
+  if (!res.ok) throw new Error(`health ${res.status}`);
+  return res.json();
+}
+
 export async function saveSettings(patch) {
   const res = await fetch("/api/settings", {
     method: "PUT",

--- a/ui/src/lib/api.js
+++ b/ui/src/lib/api.js
@@ -327,12 +327,6 @@ export async function fetchSettings() {
   return settingsInFlight;
 }
 
-export async function fetchHealth() {
-  const res = await fetch("/healthz");
-  if (!res.ok) throw new Error(`health ${res.status}`);
-  return res.json();
-}
-
 export async function saveSettings(patch) {
   const res = await fetch("/api/settings", {
     method: "PUT",

--- a/ui/src/lib/tailscaleAccess.js
+++ b/ui/src/lib/tailscaleAccess.js
@@ -1,8 +1,6 @@
 export function tailscaleAccess(health) {
   const serve = health?.tailscaleServe;
-  if (serve?.origin) return { state: "live", origin: serve.origin, kind: "Tailscale Serve", error: null };
-  const error = serve?.error || null;
-  return error
-    ? { state: "error", origin: null, kind: null, error }
-    : { state: "local", origin: null, kind: null, error: null };
+  if (!serve) return null;
+  if (serve.origin) return { state: "live", origin: serve.origin, kind: "Tailscale Serve", error: null };
+  return { state: "error", origin: null, kind: "Tailscale Serve", error: serve.error || "unavailable" };
 }

--- a/ui/src/lib/tailscaleAccess.js
+++ b/ui/src/lib/tailscaleAccess.js
@@ -1,0 +1,8 @@
+export function tailscaleAccess(health) {
+  const serve = health?.tailscaleServe;
+  if (serve?.origin) return { state: "live", origin: serve.origin, kind: "Tailscale Serve", error: null };
+  const error = serve?.error || null;
+  return error
+    ? { state: "error", origin: null, kind: null, error }
+    : { state: "local", origin: null, kind: null, error: null };
+}

--- a/ui/src/lib/tailscaleAccess.test.js
+++ b/ui/src/lib/tailscaleAccess.test.js
@@ -6,5 +6,5 @@ test("shows classic Serve status and surfaces failures", () => {
     state: "live", origin: "https://host.tail.ts.net:8443", kind: "Tailscale Serve", error: null,
   });
   expect(tailscaleAccess({ tailscaleServe: { error: "port occupied" } }).error).toBe("port occupied");
-  expect(tailscaleAccess({}).state).toBe("local");
+  expect(tailscaleAccess({})).toBeNull();
 });

--- a/ui/src/lib/tailscaleAccess.test.js
+++ b/ui/src/lib/tailscaleAccess.test.js
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { tailscaleAccess } from "./tailscaleAccess.js";
+
+test("shows classic Serve status and surfaces failures", () => {
+  expect(tailscaleAccess({ tailscaleServe: { origin: "https://host.tail.ts.net:8443" } })).toEqual({
+    state: "live", origin: "https://host.tail.ts.net:8443", kind: "Tailscale Serve", error: null,
+  });
+  expect(tailscaleAccess({ tailscaleServe: { error: "port occupied" } }).error).toBe("port occupied");
+  expect(tailscaleAccess({}).state).toBe("local");
+});


### PR DESCRIPTION
Cockpit correctly binds its Bun server to loopback, but reaching that private instance from another tailnet device requires manually operating Tailscale Serve outside the product. This adds one opt-in, end-to-end Serve path while keeping loopback as the process boundary and fallback.

## What changed

- Add `COCKPIT_TAILSCALE_SERVE=1` and optional `COCKPIT_TAILSCALE_HTTPS_PORT`.
- Resolve the node MagicDNS name, inspect the existing Serve root, refuse route collisions, and publish HTTPS to `http://127.0.0.1:<port>`.
- Merge only the exact published HTTPS origin into browser-origin trust.
- Report Serve state through `/healthz` and show it in Settings and onboarding.
- Persist the opt-in environment in macOS LaunchAgent and Linux systemd installations.
- Keep mock mode isolated from the real Tailscale CLI.

Missing `tailscale`, an unavailable daemon, invalid status, or a Serve error returns a visible status error but never prevents the loopback server from starting. The command path never invokes Funnel and never binds Bun to a non-loopback address.

## Verification

- `bun test server/tailscaleServe.test.ts ui/src/lib/tailscaleAccess.test.js scripts/cockpit.test.ts` — 10 passed.
- Focused macOS and Linux installer tests pass.
- `cd ui && bun run build`.
- Tests cover opt-in defaults, missing dependency fallback, failed daemon fallback, route collisions, custom HTTPS ports, exact origin merging, no Funnel, and loopback-only Bun binding.

## Screenshots

| Before | After |
|---|---|
| ![Settings before private Tailscale access status](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/tailscale/before.png) | ![Settings showing a live Tailscale Serve origin](https://raw.githubusercontent.com/umgbhalla/pr-cockpit/09d4c7452fb5acedfc186a5b4f7f84712ed3c5c5/screenshots/tailscale/after.png) |

## Defaults

- [x] New functionality is off by default, if applicable. Serve runs only with `COCKPIT_TAILSCALE_SERVE=1`.
- [x] Styling is opt-in, or this is minor polish that preserves the default appearance. The status row uses existing Settings field styles.
